### PR TITLE
Add option --delete-frame (-x)

### DIFF
--- a/convert.cpp
+++ b/convert.cpp
@@ -1,13 +1,72 @@
 #include <cstdio>
 #include <iostream>
 #include <id3/tag.h>
+#include <id3/globals.h>
 #include <cstdlib>
+#include "frametable.h"
+
+void DeleteSpecificTag(int argc, char *argv[], char* optarg, int optind, int whichTags)
+{
+    FILE * fp;
+
+    for (size_t nIndex = optind; nIndex < argc; nIndex++)
+    {
+      fp = fopen(argv[nIndex], "r+");
+      if (fp == NULL) {
+        fprintf(stderr, "fopen: %s: ", argv[nIndex]);
+        perror("id3v2");
+        continue;
+      }
+      fclose(fp);
+
+      ID3_Tag myTag;
+
+      std::cout << "Deleting id3 tag in \"";
+      std::cout << argv[nIndex] << "\"...";
+
+      myTag.Clear();
+      myTag.Link(argv[nIndex], ID3TT_ALL);
+
+      ID3_FrameID myFrameID;
+      ID3_Frame*  myFrame;
+
+      switch(whichTags)
+      {
+        case 1:
+        case 2:
+        case 0:
+        default:
+
+          for (int i = 0; i < frameTableCount; i++)
+          {
+              if (0 == strcmp(frameTable[i].frameName, optarg)) {
+                  myFrameID = frameTable[i].frameID;
+              }
+          }
+
+          if (myFrameID == ID3FID_NOFRAME) {
+            std::cout << "\nFrame not implemented.\n" << std::endl;
+            exit(1);
+          }
+
+          if (myFrame = myTag.Find(myFrameID))
+          {
+              myTag.RemoveFrame(myFrame);
+              myTag.Update();
+          }
+      }
+
+      std::cout << "deleted." << std::endl;
+    }
+
+    return;
+}
 
 void DeleteTag(int argc, char *argv[], int optind, int whichTags)
 {
 
     FILE * fp;
-    
+
     for (size_t nIndex = optind; nIndex < argc; nIndex++)
     {
       /* cludgy to check if we have the proper perms */
@@ -28,16 +87,16 @@ void DeleteTag(int argc, char *argv[], int optind, int whichTags)
       myTag.Link(argv[nIndex], ID3TT_ALL);
 
       luint nTags;
-      switch(whichTags) 
+      switch(whichTags)
       {
-        case 1: 
+        case 1:
           nTags = myTag.Strip(ID3TT_ID3V1);
           std::cout << "id3v1 ";
           break;
         case 2:
           nTags = myTag.Strip(ID3TT_ID3V2);
           std::cout << "id3v2 ";
-          break; 
+          break;
         case 0:
         default:
           nTags = myTag.Strip(ID3TT_ID3);

--- a/convert.cpp
+++ b/convert.cpp
@@ -44,11 +44,6 @@ void DeleteSpecificTag(int argc, char *argv[], char* optarg, int optind, int whi
               }
           }
 
-          if (myFrameID == ID3FID_NOFRAME) {
-            std::cout << "\nFrame not implemented.\n" << std::endl;
-            exit(1);
-          }
-
           if (myFrame = myTag.Find(myFrameID))
           {
               myTag.RemoveFrame(myFrame);

--- a/convert.cpp
+++ b/convert.cpp
@@ -21,7 +21,7 @@ void DeleteSpecificTag(int argc, char *argv[], char* optarg, int optind, int whi
 
       ID3_Tag myTag;
 
-      std::cout << "Deleting id3 tag in \"";
+      std::cout << "Deleting id3v2 frame \"" << optarg << "\" in \"";
       std::cout << argv[nIndex] << "\"...";
 
       myTag.Clear();

--- a/create_map.cpp
+++ b/create_map.cpp
@@ -2,12 +2,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-//  
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-//  
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.

--- a/frametable.h
+++ b/frametable.h
@@ -27,7 +27,7 @@ struct frameTbl {
   char *frameName;
   enum ID3_FrameID frameID;
   char *frameLongName;
-}; 
+};
 
 static struct frameTbl frameTable[] = {
   { "AENC", ID3FID_AUDIOCRYPTO,  	    "Audio encryption" },
@@ -84,7 +84,7 @@ static struct frameTbl frameTable[] = {
 	{ "TPOS", ID3FID_PARTINSET,         "Part of a set" },
 	{ "TPUB", ID3FID_PUBLISHER,         "Publisher" },
 	{ "TRCK", ID3FID_TRACKNUM,          "Track number/Position in set" },
-	{ "TRDA", ID3FID_RECORDINGDATES,    "Recording dates" }, 
+	{ "TRDA", ID3FID_RECORDINGDATES,    "Recording dates" },
 	{ "TRSN", ID3FID_NETRADIOSTATION,   "Internet radio station name" },
 	{ "TRSO", ID3FID_NETRADIOOWNER,     "Internet radio station owner" },
 	{ "TSIZ", ID3FID_SIZE,              "Size" },
@@ -108,7 +108,7 @@ static struct frameTbl frameTable[] = {
   { "????", ID3FID_NOFRAME,           "Error" }
 };
 
-int frameTableCount = 75;
+static int frameTableCount = 75;
 
 
 #endif /* __FRAMETABLE_H__ */

--- a/genre.cpp
+++ b/genre.cpp
@@ -2,12 +2,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-//  
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-//  
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
@@ -137,9 +137,9 @@ char *genre_table[] = {"Blues",
                        "Primus",
                        "Porn Groove",
                        "Satire",
- /* The following were added 1999 26 Apr by Ben Gertzfield <che@debian.org> 
-  * as per the list at http://mp3.musichall.cz/id3master/faq.htm but with a 
-  * few spell-checks confirmed by running 'strings' on the in_mp3.dll file 
+ /* The following were added 1999 26 Apr by Ben Gertzfield <che@debian.org>
+  * as per the list at http://mp3.musichall.cz/id3master/faq.htm but with a
+  * few spell-checks confirmed by running 'strings' on the in_mp3.dll file
   * from winamp 2.10 (sorry :)
   */
 		       "Slow Jam",

--- a/id3v2.1
+++ b/id3v2.1
@@ -32,6 +32,9 @@ Lists the tag(s) on the file(s)
 .B \-R, \-\-list-rfc822
 Lists using an rfc822\-style format for output
 .TP
+.B \-x, \-\-delete\-frame
+Deletes the frame FRAME (id3v2 only)
+.TP
 .B \-d, \-\-delete\-v2
 Deletes id3v2 tags
 .TP

--- a/id3v2.1
+++ b/id3v2.1
@@ -32,7 +32,7 @@ Lists the tag(s) on the file(s)
 .B \-R, \-\-list-rfc822
 Lists using an rfc822\-style format for output
 .TP
-.B \-x, \-\-delete\-frame
+.B \-x, \-\-delete\-frame FRAME
 Deletes the frame FRAME (id3v2 only)
 .TP
 .B \-d, \-\-delete\-v2

--- a/id3v2.cpp
+++ b/id3v2.cpp
@@ -36,7 +36,7 @@ void PrintUsage(char *sName)
   std::cout << "  -v,  --version               Display version information and exit" << std::endl;
   std::cout << "  -l,  --list                  Lists the tag(s) on the file(s)" << std::endl;
   std::cout << "  -R,  --list-rfc822           Lists using an rfc822-style format for output" << std::endl;
-  std::cout << "  -x   --delete-frame \"FRAME\"  Deletes the id3v2 frame FRAME" << std::endl;
+  std::cout << "  -x   --delete-frame \"FRAME\"  Deletes the frame FRAME (id3v2 only)" << std::endl;
   std::cout << "  -d,  --delete-v2             Deletes id3v2 tags" << std::endl;
   std::cout << "  -s,  --delete-v1             Deletes id3v1 tags" << std::endl;
   std::cout << "  -D,  --delete-all            Deletes both id3v1 and id3v2 tags" << std::endl;
@@ -47,8 +47,8 @@ void PrintUsage(char *sName)
   std::cout << "  -A,  --album   \"ALBUM\"       Set the album title information" << std::endl;
   std::cout << "  -t,  --song    \"SONG\"        Set the song title information" << std::endl;
   std::cout << "  -c,  --comment \"DESCRIPTION\":\"COMMENT\":\"LANGUAGE\"  "<< std::endl
-       << "                               Set the comment information (both" << std::endl
-       << "                               description and language optional)" << std::endl;
+            << "                               Set the comment information (both" << std::endl
+            << "                               description and language optional)" << std::endl;
   std::cout << "  -g,  --genre   num           Set the genre number" << std::endl;
   std::cout << "  -y,  --year    num           Set the year" << std::endl;
   std::cout << "  -T,  --track   num/num       Set the track number/(optional) total tracks" << std::endl;
@@ -68,7 +68,7 @@ void PrintVersion(char *sName)
   std::cout << "Uses " << ID3LIB_FULL_NAME << std::endl << std::endl;
 
   std::cout << "This program adds/modifies/removes/views id3v2 tags, " << std::endl
-       << "and can convert from id3v1 tags" << std::endl;
+            << "and can convert from id3v1 tags" << std::endl;
 }
 
 
@@ -107,26 +107,21 @@ int main( int argc, char *argv[])
     static struct option long_options[] =
     {
     // help and info
-      { "help",    no_argument,       &iLongOpt, 'h' },
-      { "list-frames",
-                   no_argument,       &iLongOpt, 'f' },
-      { "list-genres",
-                  no_argument,        &iLongOpt, 'L' },
-      { "version", no_argument,       &iLongOpt, 'v' },
+      { "help",        no_argument,        &iLongOpt, 'h' },
+      { "list-frames", no_argument,        &iLongOpt, 'f' },
+      { "list-genres", no_argument,        &iLongOpt, 'L' },
+      { "version",     no_argument,        &iLongOpt, 'v' },
 
     // list / remove / convert
-      { "list",   no_argument,        &iLongOpt, 'l' },
-      { "list-rfc822",
-                   no_argument,       &iLongOpt, 'R' },
+      { "list",         no_argument,       &iLongOpt, 'l' },
+      { "list-rfc822",  no_argument,       &iLongOpt, 'R' },
       { "delete-frame", required_argument, &iLongOpt, 'x' },
-      { "delete-v2",  no_argument,    &iLongOpt, 'd' },
-      { "delete-v1",
-                   no_argument,       &iLongOpt, 's' },
-      { "delete-all",
-                   no_argument,       &iLongOpt, 'D' },
-      { "convert", no_argument,       &iLongOpt, 'C' },
-      { "id3v1-only", no_argument,       &iLongOpt, '1' },
-      { "id3v2-only", no_argument,       &iLongOpt, '2' },
+      { "delete-v2",    no_argument,       &iLongOpt, 'd' },
+      { "delete-v1",    no_argument,       &iLongOpt, 's' },
+      { "delete-all",   no_argument,       &iLongOpt, 'D' },
+      { "convert",      no_argument,       &iLongOpt, 'C' },
+      { "id3v1-only",   no_argument,       &iLongOpt, '1' },
+      { "id3v2-only",   no_argument,       &iLongOpt, '2' },
 
     // infomation to tag
       { "artist",  required_argument, &iLongOpt, 'a' },
@@ -212,7 +207,7 @@ int main( int argc, char *argv[])
       { "WXXX",    required_argument, &optFrameID, ID3FID_WWWUSER },
       { 0, 0, 0, 0 }
     };
-    iOpt = getopt_long (argc, argv, "12hfLvlRdsDCa:A:t:c:g:y:T:",
+    iOpt = getopt_long (argc, argv, "12hfLvlRx:dsDCa:A:t:c:g:y:T:",
                         long_options, &option_index);
 
     if (iOpt == -1  && argCounter == 0)

--- a/list.cpp
+++ b/list.cpp
@@ -2,12 +2,12 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
-//  
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-//  
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
@@ -40,7 +40,7 @@ void PrintFrameHelp(char *sName)
 {
     for(int ii = 0; ii < frameTableCount - 1; ii++ )
     {
-      std::cout << "    --" << frameTable[ii].frameName << "    " 
+      std::cout << "    --" << frameTable[ii].frameName << "    "
            << frameTable[ii].frameLongName << std::endl;
     }
     return;
@@ -70,7 +70,7 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
     }
 
     if (NULL != myFrame)
-    { 
+    {
       const char* desc = myFrame->GetDescription();
       if (!desc) desc = "";
       if (rfc822)
@@ -142,8 +142,8 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
         }
         case ID3FID_USERTEXT:
         {
-          char 
-            *sText = ID3_GetString(myFrame, ID3FN_TEXT), 
+          char
+            *sText = ID3_GetString(myFrame, ID3FN_TEXT),
             *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION);
           std::cout << "(" << sDesc << "): " << sText << std::endl;
           delete [] sText;
@@ -153,9 +153,9 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
         case ID3FID_COMMENT:
         case ID3FID_UNSYNCEDLYRICS:
         {
-          char 
-            *sText = ID3_GetString(myFrame, ID3FN_TEXT), 
-            *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION), 
+          char
+            *sText = ID3_GetString(myFrame, ID3FN_TEXT),
+            *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION),
             *sLang = ID3_GetString(myFrame, ID3FN_LANGUAGE);
           std::cout << "(" << sDesc << ")[" << sLang << "]: "
                << sText << std::endl;
@@ -180,7 +180,7 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
         }
         case ID3FID_WWWUSER:
         {
-          char 
+          char
             *sURL = ID3_GetString(myFrame, ID3FN_URL),
             *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION);
           std::cout << "(" << sDesc << "): " << sURL << std::endl;
@@ -224,12 +224,12 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
         }
         case ID3FID_GENERALOBJECT:
         {
-          char 
-          *sMimeType = ID3_GetString(myFrame, ID3FN_MIMETYPE), 
-          *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION), 
+          char
+          *sMimeType = ID3_GetString(myFrame, ID3FN_MIMETYPE),
+          *sDesc = ID3_GetString(myFrame, ID3FN_DESCRIPTION),
           *sFileName = ID3_GetString(myFrame, ID3FN_FILENAME);
           size_t nDataSize = myFrame->GetField(ID3FN_DATA)->Size();
-          std::cout << "(" << sDesc << ")[" 
+          std::cout << "(" << sDesc << ")["
                << sFileName << "]: " << sMimeType << ", " << nDataSize
                << " bytes" << std::endl;
           delete [] sMimeType;
@@ -258,7 +258,7 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
           size_t
             nCounter = myFrame->Field(ID3FN_COUNTER).Get(),
             nRating = myFrame->Field(ID3FN_RATING).Get();
-          std::cout << sEmail << ", counter=" 
+          std::cout << sEmail << ", counter="
                << nCounter << " rating=" << nRating;
           delete [] sEmail;
           break;
@@ -267,7 +267,7 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
         case ID3FID_GROUPINGREG:
         {
           char *sOwner = ID3_GetString(myFrame, ID3FN_OWNER);
-          size_t 
+          size_t
             nSymbol = myFrame->Field(ID3FN_ID).Get(),
             nDataSize = myFrame->Field(ID3FN_DATA).Size();
           std::cout << "(" << nSymbol << "): " << sOwner
@@ -302,12 +302,12 @@ int PrintInformation(char *sFileName, const ID3_Tag &myTag, int rfc822)
   }
   if(firstLine)
     return 1;
-  
+
   return 0;
 }
 
-int PrintID3v1Tag(char *sFileName) 
-// code from id3 
+int PrintID3v1Tag(char *sFileName)
+// code from id3
 {
   struct id3 {
     char tag[3];
@@ -321,7 +321,7 @@ int PrintID3v1Tag(char *sFileName)
     unsigned char genre;
   } id3v1tag;
   FILE *fp;
-  
+
   fp = fopen(sFileName, "r"); /* read only */
 
   if (fp == NULL) { /* file didn't open */
@@ -331,14 +331,14 @@ int PrintID3v1Tag(char *sFileName)
   }
   if (fseek(fp, -128, SEEK_END) < 0) {
     /* problem rewinding */
-  } else { /* we rewound successfully */ 
+  } else { /* we rewound successfully */
     if (fread(&id3v1tag, 128, 1, fp) != 1) {
       /* read error */
       fprintf(stderr, "fread: %s: ", sFileName);
       perror("");
     }
   }
-    
+
   fclose(fp);
 
     /* This simple detection code has a 1 in 16777216
@@ -346,27 +346,27 @@ int PrintID3v1Tag(char *sFileName)
      * bytes of your mp3 if it isn't tagged. ID3 ain't
      * world peace, live with it.
      */
-    
-  
+
+
   if (!strncmp(id3v1tag.tag, "TAG", 3))
   {
     std::cout << "id3v1 tag info for " << sFileName << ":" << std::endl;
     printf("Title  : %-30.30s  Artist: %-30.30s\n",
             id3v1tag.title, id3v1tag.artist);
     printf("Album  : %-30.30s  Year: %-4.4s, Genre: %s (%d)\n",
-            id3v1tag.album, id3v1tag.year, 
+            id3v1tag.album, id3v1tag.year,
             (id3v1tag.genre < GetGenreCount())
-            ? GetGenreFromNum(id3v1tag.genre) : 
+            ? GetGenreFromNum(id3v1tag.genre) :
             "Unknown", id3v1tag.genre);
     if (!id3v1tag.comment[28])
-      printf("Comment: %-28.28s    Track: %d\n", 
+      printf("Comment: %-28.28s    Track: %d\n",
              id3v1tag.comment, id3v1tag.comment[29]);
     else
       printf("Comment: %-30.30s\n", id3v1tag.comment);
-  } 
-  else 
+  }
+  else
   {
-    return 1;     
+    return 1;
   }
   return 0;
 }


### PR DESCRIPTION
This patch adds the --delete-frame (-x) option to the id3v2 program. Searching through the documentation and inspecting the source code I couldn't find a possibility to only delete a specific ID3v2 frame from a file.

This patch adds the --delete-frame (-x) option that, given a required argument of a ID3v2 frame as string, does just that.

If that feature already exists I'd like to apologize, but ask for better documentation instead. In case the feature exists and is documented properly I'd like to apologize and ask just to ignore this patch, although a comment would be appreciated in that case.

Not being an experienced CPP coder I'd appreciate a careful review of this patch before applying it to master.

Only deletion of ID3v2 frames is implemented and this is documented in the help and manpage. If multiple frames are found, only the first occurence is deleted. If no frame exists in the ID3v2 tag or the given frame is not valid no error occurs.

Here are some examples.

```
$ touch mp3
$ id3v2 -l mp3
mp3: No ID3 tag
$ id3v2 --COMM "Some comment." mp3
$ id3v2 --COMM "Second comment." mp3
$ id3v2 -l mp3 | grep COMM
COMM (Comments): (ID3v1 Comment)[XXX]: Some comment.
COMM (Comments): ()[]: Second comment.
$ id3v2 --delete-frame COMM mp3
Deleting id3v2 frame "COMM" in "mp3"...deleted.
$ id3v2 -l mp3 | grep COMM
COMM (Comments): (ID3v1 Comment)[XXX]: Second comment.
$ id3v2 -x COMM mp3 > /dev/null
$ id3v2 -l mp3 | grep COMM; echo $?
1
$ id3v2 -x COMM mp3
Deleting id3v2 frame "COMM" in "mp3"...deleted.
$ id3v2 -x NO_SUCH_FRAME mp3
Deleting id3v2 frame "NO_SUCH_FRAME" in "mp3"...deleted.
```

Additionally this patch removes some unnecessary whitespaces and fixes indentation in some parts of the files. The former was an unintended side-effect. I hope this won't hold the patch from being committed.
